### PR TITLE
Feature/long press mapping for user inputs trip odometer resetting

### DIFF
--- a/QtDash/VolvoDigitalDashModels/app/config.h
+++ b/QtDash/VolvoDigitalDashModels/app/config.h
@@ -88,6 +88,8 @@ public:
     static constexpr char USER_INPUT3_MAP[] = "input_3_map";
     static constexpr char USER_INPUT4_MAP[] = "input_4_map";
     static constexpr Qt::Key USER_INPUT_DEFAULT_KEY = Qt::Key::Key_A;
+    static constexpr char USER_INPUT_LONG_PRESS_DURATION[] = "long_press_msec";
+    static constexpr int DEFAULT_LONG_PRESS_DURATION_MSEC = 3000;
 
     //expected map sensor keys
     static constexpr char PRESSURE_AT_0V[] = "p_0v";
@@ -760,6 +762,8 @@ public:
                 mUserInputConfig.insert(2, mKeyMap.value(mConfig->value(key, "Key_B").toString(), USER_INPUT_DEFAULT_KEY));
             } else if (QString::compare(key, USER_INPUT4_MAP) == 0) {
                 mUserInputConfig.insert(3, mKeyMap.value(mConfig->value(key, "Key_Right").toString(), USER_INPUT_DEFAULT_KEY));
+            } else if (QString::compare(key, USER_INPUT_LONG_PRESS_DURATION) == 0) {
+                mUserInputPinConfig.insert(key, mConfig->value(key, DEFAULT_LONG_PRESS_DURATION_MSEC).toInt());
             } else {
                 mUserInputPinConfig.insert(key, mConfig->value(key).toInt());
             }

--- a/QtDash/VolvoDigitalDashModels/app/dash_new.h
+++ b/QtDash/VolvoDigitalDashModels/app/dash_new.h
@@ -578,16 +578,17 @@ private:
 
         // hook up long press events -- this will need to be configurable at some point:
         QObject::connect(mDashLights, &DashLights::userInputLongPress, [=] (uint8_t n) {
+            qDebug() << "Long press detected: " << n;
             switch(n) {
-            case 1:
+            case 0:
                 break;
-            case 2:
+            case 1:
                 mTripAOdoSensor->reset();
                 break;
-            case 3:
+            case 2:
                 mTripBOdoSensor->reset();
                 break;
-            case 4:
+            case 3:
                 break;
             default:
                 break;

--- a/QtDash/VolvoDigitalDashModels/app/dash_new.h
+++ b/QtDash/VolvoDigitalDashModels/app/dash_new.h
@@ -567,11 +567,30 @@ private:
         mDashLights = new DashLights(this->parent(), &mConfig);
         mDashLights->init();
 
+        // Hook up key press events
         QObject::connect(mDashLights, &DashLights::userInputActive, [=] (uint8_t n) {
             QKeyEvent * event = nullptr;
             if (n <= 3) {
                 event = new QKeyEvent(QKeyEvent::KeyPress, mConfig.geUserInputConfig().value(n, Qt::Key::Key_Left), Qt::NoModifier);
                 emit keyPress(event);
+            }
+        });
+
+        // hook up long press events -- this will need to be configurable at some point:
+        QObject::connect(mDashLights, &DashLights::userInputLongPress, [=] (uint8_t n) {
+            switch(n) {
+            case 1:
+                break;
+            case 2:
+                mTripAOdoSensor->reset();
+                break;
+            case 3:
+                mTripBOdoSensor->reset();
+                break;
+            case 4:
+                break;
+            default:
+                break;
             }
         });
 


### PR DESCRIPTION
- added long press to reset trip A and trip B using user inputs 1 and 2 (left and right are 0 and 3 respectively).  
- default long press time set to 3 seconds, can be configured from config.ini