### PR TITLE
feature/72: Add configuration option for screen rotation

### DIFF
--- a/QtDash/VolvoDigitalDashModels/app/app.pro
+++ b/QtDash/VolvoDigitalDashModels/app/app.pro
@@ -428,6 +428,7 @@ HEADERS += \
     inc/config/config.h \
     inc/config/config_keys.h \
     inc/config/gauge_configs.h \
+    inc/config/screen_configs.h \
     inc/config/sensor_configs.h \
     inc/dash/dash.h \
     inc/dash/dash_host.h \

--- a/QtDash/VolvoDigitalDashModels/app/inc/config/config.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/config/config.h
@@ -4,15 +4,19 @@
 #include <QObject>
 #include <QSettings>
 #include <QDebug>
+
 #include <iostream>
+#include <memory>
 
 #include <config_keys.h>
 #include <can_frame_config.h>
-#include <units.h>
-
-#include <analog_12v_input.h>
 #include <sensor_configs.h>
 #include <gauge_configs.h>
+#include <screen_configs.h>
+
+#include <units.h>
+#include <analog_12v_input.h>
+
 
 /**
  * @brief Dash config class
@@ -98,11 +102,13 @@ public:
      */
     bool loadConfig();
 
+    bool loadScreenConfig();
+
     /**
      * @brief Print all child keys for the current config subgroup
      * @param setting: Group name to output to log
      */
-    void printKeys(QString setting, QSettings * config) const {
+    void printKeys(QString setting, const QSettings * config) const {
         for (auto key : config->childKeys()) {
             qDebug() << setting << key << ": " << config->value(key, "N/A").toStringList();
         }
@@ -287,12 +293,20 @@ public:
         return mSensorSupplyVoltage;
     }
 
+    qreal getScreenRotation() const {
+        if (mScreenConfig.use) {
+            return mScreenConfig.screenRotationAngle;
+        } else {
+            return 180;
+        }
+    }
+
 signals:
 
 public slots:
 
 private:
-    QSettings * mConfig = nullptr;  //!< QSettings for reading config.ini file
+    std::unique_ptr<QSettings> mConfig = nullptr;  //!< QSettings for reading config.ini file
     QMap<QString, int> mSensorChannelConfig; //!< sensor channel configuration
     qreal mSensorSupplyVoltage = ConfigKeys::DEFAULT_V_SUPPLY; //!< Sensor supply voltage
     QMap<QString, int> mDashLightConfig; //!< dash light gpio configuration
@@ -303,19 +317,20 @@ private:
     SensorConfig::TachInputConfig mTachConfig; //!< Tach signal input configuration
     QMap<QString, SensorConfig::ResistiveSensorConfig> mResistiveSensorConfig; //!< Resistive sensor configs
     QMap<QString, Analog12VInput::Analog12VInputConfig> mAnalog12VInputConfig; //!< 12V analog configs
+    ScreenConfigs::ScreenConfig_t mScreenConfig;
 
-    QSettings * mGaugeConfig = nullptr; //!< Gauge config QSettings
+    std::unique_ptr<QSettings> mGaugeConfig = nullptr; //!< Gauge config QSettings
     QMap<QString, GaugeConfig::GaugeConfig> mGaugeConfigs; //!< map of gauge configs
     GaugeConfig::SpeedoConfig mSpeedoGaugeConfig; //!< speedo gauge config
     GaugeConfig::TachoConfig mTachGaugeConfig; //!< tacho gauge config
     SensorConfig::VssInputConfig mVssInputConfig; //!< vehicle speed sensor config
 
-    QSettings * mOdometerConfig = nullptr; //!< odometer configration QSettings
+    std::unique_ptr<QSettings> mOdometerConfig = nullptr; //!< odometer configration QSettings
     QList<SensorConfig::OdometerConfig> mOdoConfig; //!< odometer config
 
     BacklightControlConfig_t mBacklightConfig; //!< backlight configuration
 
-    QSettings * mCanConfig; //!< can config Qsettings
+    std::unique_ptr<QSettings> mCanConfig; //!< can config Qsettings
     bool mEnableCan = false; //!< is Can enabled
     QList<CanFrameConfig> mCanFrameConfigs; //!< CAN frame configss
 

--- a/QtDash/VolvoDigitalDashModels/app/inc/config/config_keys.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/config/config_keys.h
@@ -218,6 +218,11 @@ namespace ConfigKeys {
     static constexpr char CAN_FRAME_ADD[] = "add";
     static constexpr char CAN_FRAME_GAUGE[] = "gauge";
 
+    //screen properties keys
+    static constexpr char SCREEN_PROP_GROUP[] = "screen_prop";
+    static constexpr char SCREEN_PROP_USE[] = "use";
+    static constexpr char SCREEN_PROP_ORIENTATION[] = "orientation_angle";
+
 }
 
 #endif // CONFIG_KEYS_H

--- a/QtDash/VolvoDigitalDashModels/app/inc/config/gauge_configs.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/config/gauge_configs.h
@@ -52,7 +52,6 @@ namespace GaugeConfig {
         qreal maxRpm; //!< maximum rpm -- lowest possible value will help filter out noisier data
         qreal redline; //!< defines when numerical RPM indication will turn red
     };
-
 }
 
 #endif // GAUGE_CONFIGS_H

--- a/QtDash/VolvoDigitalDashModels/app/inc/config/screen_configs.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/config/screen_configs.h
@@ -1,0 +1,17 @@
+#ifndef SCREEN_CONFIGS_H
+#define SCREEN_CONFIGS_H
+
+#include <qtypeinfo.h>
+#include <QString>
+
+namespace ScreenConfigs {
+    /**
+     * screen configuration settings
+     */
+    using ScreenConfig_t = struct SCREEN_CONFIG {
+        bool use = false; //!< default don't use
+        qreal screenRotationAngle = 180; //!< default for pi
+    };
+}
+
+#endif // SCREEN_CONFIGS_H

--- a/QtDash/VolvoDigitalDashModels/app/inc/config/sensor_configs.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/config/sensor_configs.h
@@ -1,6 +1,8 @@
 #ifndef SENSOR_CONFIGS_H
 #define SENSOR_CONFIGS_H
 
+#include <units.h>
+
 namespace SensorConfig {
     static constexpr qreal INVALID_TEMP = -459.67; // value if temp could not be read
 

--- a/QtDash/VolvoDigitalDashModels/app/inc/dash/dash.h
+++ b/QtDash/VolvoDigitalDashModels/app/inc/dash/dash.h
@@ -89,6 +89,10 @@ public:
         mEventTiming.stop();
     }
 
+    const Config& getConfig() const {
+        return mConfig;
+    }
+
 signals:
     void keyPress(QKeyEvent * event);
 

--- a/QtDash/VolvoDigitalDashModels/app/main.qml
+++ b/QtDash/VolvoDigitalDashModels/app/main.qml
@@ -119,11 +119,7 @@ Window {
     Item {
         id: loading
         anchors.fill: parent
-        rotation: if (RASPBERRY_PI) {
-                      180
-                  } else {
-                      0
-                  }
+        rotation: SCREEN_ROTATION_ANGLE
         Rectangle {
             anchors.fill: parent
             color: "black"
@@ -158,11 +154,7 @@ Window {
         id: gaugeItem
         anchors.fill: parent
         focus: true
-        rotation: if (RASPBERRY_PI) {
-                      180
-                  } else {
-                      0
-                  }
+        rotation: SCREEN_ROTATION_ANGLE
         property bool initialLoad: true
         antialiasing: true
         smooth: true

--- a/QtDash/VolvoDigitalDashModels/app/src/config/config.cpp
+++ b/QtDash/VolvoDigitalDashModels/app/src/config/config.cpp
@@ -5,29 +5,35 @@ using namespace ConfigKeys;
 Config::Config(QObject * parent, QString configPath,
        QString gaugeConfigPath, QString odoConfigPath,
        QString canConfigPath): QObject(parent) {
-    mConfig = new QSettings(configPath, QSettings::IniFormat);
+
+    mConfig.reset(
+        new QSettings(
+            configPath,
+            QSettings::IniFormat
+        )
+    );
     loadConfig();
 
-    mGaugeConfig = new QSettings(gaugeConfigPath, QSettings::IniFormat);
+    mGaugeConfig.reset(new QSettings(gaugeConfigPath, QSettings::IniFormat));
     loadGaugeConfigs();
 
-    mOdometerConfig = new QSettings(odoConfigPath, QSettings::IniFormat);
+    mOdometerConfig.reset(new QSettings(odoConfigPath, QSettings::IniFormat));
     loadOdometerConfigs();
 
-    mCanConfig = new QSettings(canConfigPath, QSettings::IniFormat);
+    mCanConfig.reset(new QSettings(canConfigPath, QSettings::IniFormat));
     loadCanFrameConfigs();
 }
 
 bool Config::loadCanFrameConfigs() {
     // parse enable/disable
     mCanConfig->beginGroup(CAN_CONFIG_START);
-    printKeys("can", mCanConfig);
+    printKeys("can", mCanConfig.get());
     mEnableCan = mCanConfig->value(CAN_CONFIG_ENABLE, false).toBool();
     mCanConfig->endGroup();
 
     // dump keys to log
     mCanConfig->beginGroup(CAN_FRAME);
-    printKeys("can", mCanConfig);
+    printKeys("can", mCanConfig.get());
     mCanConfig->endGroup();
 
     // parse can frame data configs
@@ -63,7 +69,7 @@ bool Config::loadCanFrameConfigs() {
         }
 
         mCanFrameConfigs.append(config);
-        printKeys("can: ", mCanConfig);
+        printKeys("can: ", mCanConfig.get());
     }
     mCanConfig->endArray();
 
@@ -73,11 +79,11 @@ bool Config::loadCanFrameConfigs() {
 bool Config::loadOdometerConfigs() {
 
     mOdometerConfig->beginGroup("start");
-    printKeys("odo", mOdometerConfig);
+    printKeys("odo", mOdometerConfig.get());
     mOdometerConfig->endGroup();
 
     mOdometerConfig->beginGroup(ODOMETER_GROUP);
-    printKeys("odo", mOdometerConfig);
+    printKeys("odo", mOdometerConfig.get());
     mOdometerConfig->endGroup();
 
     int size = mOdometerConfig->beginReadArray(ODOMETER_GROUP);
@@ -92,7 +98,7 @@ bool Config::loadOdometerConfigs() {
         conf.name = mOdometerConfig->value(ODO_NAME, "").toString();
 
         mOdoConfig.push_back(conf);
-        printKeys("odo-vals", mOdometerConfig);
+        printKeys("odo-vals", mOdometerConfig.get());
     }
 
     mOdometerConfig->endArray();
@@ -195,7 +201,7 @@ bool Config::loadGaugeConfigs() {
     mSpeedoGaugeConfig.topSource = mGaugeConfig->value(TOP_VALUE_SOURCE).toString();
     mSpeedoGaugeConfig.topUnits = mGaugeConfig->value(TOP_VALUE_UNITS).toString();
 
-    printKeys("Speedometer: ", mGaugeConfig);
+    printKeys("Speedometer: ", mGaugeConfig.get());
 
     mGaugeConfig->endGroup();
 
@@ -204,7 +210,7 @@ bool Config::loadGaugeConfigs() {
     mTachGaugeConfig.maxRpm = mGaugeConfig->value(MAX_RPM).toInt();
     mTachGaugeConfig.redline = mGaugeConfig->value(REDLINE).toInt();
 
-    printKeys("Tachometer: ", mGaugeConfig);
+    printKeys("Tachometer: ", mGaugeConfig.get());
 
     mGaugeConfig->endGroup();
 
@@ -227,7 +233,7 @@ GaugeConfig::GaugeConfig Config::loadGaugeConfig(QString groupName) {
     conf.altDisplayUnits.aboveCutoff = mGaugeConfig->value(ALT_UNITS_ABOVE_THRS, false).toBool();
     conf.altDisplayUnits.cutoff = mGaugeConfig->value(ALT_UNITS_THRESHOLD, 0.0).toReal();
 
-    printKeys(groupName, mGaugeConfig);
+    printKeys(groupName, mGaugeConfig.get());
 
     mGaugeConfig->endGroup();
 
@@ -248,7 +254,7 @@ bool Config::loadConfig() {
         }
     }
 
-    printKeys("Sensor Channels ", mConfig);
+    printKeys("Sensor Channels ", mConfig.get());
 
     mConfig->endGroup();
 
@@ -259,7 +265,7 @@ bool Config::loadConfig() {
         mDashLightConfig.insert(key, mConfig->value(key, -1).toInt());
     }
 
-    printKeys("Dash Light Config ", mConfig);
+    printKeys("Dash Light Config ", mConfig.get());
 
     mConfig->endGroup();
 
@@ -282,7 +288,7 @@ bool Config::loadConfig() {
         }
     }
 
-    printKeys("User Inputs: ", mConfig);
+    printKeys("User Inputs: ", mConfig.get());
     mConfig->endGroup();
 
     //load map sensor config
@@ -302,7 +308,7 @@ bool Config::loadConfig() {
         }
     }
 
-    printKeys("Map Sensor ", mConfig);
+    printKeys("Map Sensor ", mConfig.get());
 
     mConfig->endGroup();
 
@@ -337,7 +343,7 @@ bool Config::loadConfig() {
 
         mTempSensorConfigs.append(conf);
 
-        printKeys("Temp Sensor ", mConfig);
+        printKeys("Temp Sensor ", mConfig.get());
     }
     mConfig->endArray();
 
@@ -348,7 +354,7 @@ bool Config::loadConfig() {
     mTachConfig.maxRpm = mConfig->value(TACH_MAX_RPM, 9000).toInt(); // default rpm is 9000 (a bit aspirational)
     mTachConfig.avgNumSamples = mConfig->value(TACH_AVG_NUM_SAMPLES, 4).toInt(); // default is to average over last 4 tach pulse spacing
 
-    printKeys("Tach Input ", mConfig);
+    printKeys("Tach Input ", mConfig.get());
 
     mConfig->endGroup();
 
@@ -399,7 +405,7 @@ bool Config::loadConfig() {
         }
 
         mResistiveSensorConfig.insert(rSensorConf.type, rSensorConf);
-        printKeys("Resistive Sensor: ", mConfig);
+        printKeys("Resistive Sensor: ", mConfig.get());
 
 
     }
@@ -438,7 +444,7 @@ bool Config::loadConfig() {
         }
 
         mAnalog12VInputConfig.insert(conf.type, conf);
-        printKeys("Analog 12V input: ", mConfig);
+        printKeys("Analog 12V input: ", mConfig.get());
     }
     mConfig->endArray();
 
@@ -456,7 +462,7 @@ bool Config::loadConfig() {
     mVssInputConfig.maxSpeed = mConfig->value(VSS_MAX_SPEED, 160).toInt();
     mVssInputConfig.useGps = mConfig->value(VSS_USE_GPS, false).toBool();
 
-    printKeys("VSS Input: ", mConfig);
+    printKeys("VSS Input: ", mConfig.get());
 
     mConfig->endGroup();
 
@@ -470,11 +476,25 @@ bool Config::loadConfig() {
     mBacklightConfig.useDimmer = mConfig->value(BACKLIGHT_USE_DIMMER, true).toBool();
     mBacklightConfig.activeLow = mConfig->value(BACKLIGHT_ACTIVE_LOW, false).toBool();
 
-    printKeys("Backlight Config: ", mConfig);
+    printKeys("Backlight Config: ", mConfig.get());
 
     mConfig->endGroup();
 
+    loadScreenConfig();
+
     return keys.size() > 0;
+}
+
+bool Config::loadScreenConfig() {
+    mConfig->beginGroup(SCREEN_PROP_GROUP);
+    mScreenConfig.use = mConfig->value(SCREEN_PROP_USE, false).toBool();
+    mScreenConfig.screenRotationAngle = mConfig->value((SCREEN_PROP_ORIENTATION), 180).toReal();
+
+    printKeys("Screen Properties: ", mConfig.get());
+
+    mConfig->endGroup();
+
+    return true;
 }
 
 bool Config::isMapConfigValid(QMap<QString, int> *map) {

--- a/QtDash/VolvoDigitalDashModels/app/src/main.cpp
+++ b/QtDash/VolvoDigitalDashModels/app/src/main.cpp
@@ -47,7 +47,9 @@ int main(int argc, char *argv[])
     // Initialize Dash
 #ifdef RASPBERRY_PI
     Dash * dash = new Dash(&app, ctxt); // new scheme with sensor source -> sensor -> gauge -> model
+
     ctxt->setContextProperty("RASPBERRY_PI", QVariant(true));
+    ctxt->setContextProperty("SCREEN_ROTATION_ANGLE", QVariant(dash->getConfig().getScreenRotation()));
 
     QObject::connect(dash, &Dash::keyPress, [&engine](QKeyEvent * ev) {
         if (ev != nullptr) {
@@ -90,6 +92,7 @@ int main(int argc, char *argv[])
 #else
     DashHost * dash = new DashHost(&app, ctxt);
     ctxt->setContextProperty("RASPBERRY_PI", QVariant(false));
+    ctxt->setContextProperty("SCREEN_ROTATION_ANGLE", QVariant(0));
 
     QObject::connect(dash, &DashHost::keyPress, [&engine](QKeyEvent * ev) {
         if (ev != nullptr) {

--- a/QtDash/config.ini
+++ b/QtDash/config.ini
@@ -131,4 +131,7 @@ min_dimmer_ratio=0.82
 max_dimmer_ratio=0.93
 use_dimmer=1
 active_low=1
+[screen_prop]
+use=true
+orientation_angle=0
 


### PR DESCRIPTION
	- added screen rotation config option to config.ini
	- screen can be rotated to any arbirary angle (0 and 180 would be the obvious choices, but I won't screen shame)
	- frame buffer is not tied to this option -- changing the image that /usr/sbin/preinit points to will be necessary
	
### config.ini changes:
```
[screen_prop]
use=true
orientation_angle=0
```
if ```use``` is false, the default screen orientation is 180 degrees.

You can do any angle you want, although you'll be greeted with something like this if you chose anything other than 0 or 180:
45 degrees
![45 degree screen rotation](https://i.imgur.com/KSkKk6R.jpeg)

### Bootup screen orientation
One thing that is not tied to this configuration is the bootup screen orientation.  That is written directly to the frame buffer when the init system starts.  To change this image to match your screen orientation you'll have to modify `/sbin/preinit`:

preinit contents for 180 screen rotation:
```
#!/bin/busybox sh

# show splash screen
fbv -d 1 /opt/splash.png > /dev/null 2>&1
#dd if=/opt/splash.fb of=/dev/fb0 bs=2457600 count=1 > dev/null 2>&1

# start real init
exec /sbin/init
```

preinit contents for 0 degrees screen rotation:
```
#!/bin/busybox sh

# show splash screen
fbv -d 1 /opt/splash_up.png > /dev/null 2>&1
#dd if=/opt/splash.fb of=/dev/fb0 bs=2457600 count=1 > dev/null 2>&1

# start real init
exec /sbin/init
```
You can get access to `preinit` to make these changes in three ways:
#### Modify buildroot
The preinit file can be found at `board/volvodash-rpi4/rootfs_overlay/sbin/preinit`.  Open `preinit` in a text editor and make the changes outlined above.  To get the change to your device, you then need to rebuild the linux image.  If you know you're going to keep it this way forever, do this.

#### Modify SD card rootfs
Pull out your SD card and plug it into your computer in which ever way works for you.  On the drive there will be three partitions.  The partition you're looking for is labeled `rootfs` and should be an ext3/ext4 partition.  You can then open `sbin/preinit/` and modify the contents as outlined above.  This would be a good option if you're just testing out what screen orientation is going to work for you. If you rebuild a linux image and overwrite your SD card, this change will be lost.

#### SSH
Following the instructions on the main README you can SSH into the device and modify the file `/sbin/preinit` using `nano`, modify the file as described above.  This is equivalent to modifying the rootfs using an SD card, so should only be used when you're testing out what screen orientation is going to work.

